### PR TITLE
Update dependencies to their latest

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,12 +3,12 @@
   :url "https://github.com/rajshahuk/clj-mu"
   :license {:name "MIT License"
             :url "https://github.com/rajshahuk/clj-mu/blob/master/LICENSE"}
-  :dependencies [[org.clojure/clojure "1.11.1"]
-                 [io.muserver/mu-server "1.0.4"]
-                 [org.clojure/tools.logging "1.2.4"]]
+  :dependencies [[org.clojure/clojure "1.11.3"]
+                 [io.muserver/mu-server "1.1.2"]
+                 [org.clojure/tools.logging "1.3.0"]]
   :profiles {:dev {:resource-paths ["test/resources"]
-                    :dependencies   [[cheshire "5.12.0"]
-                                     [clj-http "3.12.3"]
-                                     [org.slf4j/slf4j-api "2.0.11"]
-                                     [ch.qos.logback/logback-classic "1.4.14"]]}}
+                    :dependencies   [[cheshire "5.13.0"]
+                                     [clj-http "3.13.0"]
+                                     [org.slf4j/slf4j-api "2.0.13"]
+                                     [ch.qos.logback/logback-classic "1.5.6"]]}}
   :repl-options {:init-ns clj-mu.core})


### PR DESCRIPTION
mu-server is now 2.0.0 but is breaking change, so keeping at 1.1.2